### PR TITLE
Update MainMenuOverride.res

### DIFF
--- a/hud_src/resource/UI/MainMenuOverride.res
+++ b/hud_src/resource/UI/MainMenuOverride.res
@@ -2415,7 +2415,7 @@
 	{
 		"ControlName"	"CExImageButton"
 		"fieldName"		"SettingsButton"
-		"xpos"			"r160"
+		"xpos"			"c100"
 		"ypos"			"437"
 		"zpos"			"2"
 		"wide"			"150"
@@ -2462,7 +2462,7 @@
 	{
 		"ControlName"	"CExImageButton"
 		"fieldName"		"QuitButton"
-		"xpos"			"10" //"c-300"
+		"xpos"			"c-300"
 		"ypos"			"437"
 		"zpos"			"1"
 		"wide"			"150"


### PR DESCRIPTION
Basically revert the quit button and make the options button much closer so they aren't both very close to left or right which looks weird compared to default main menu. IIRC this was made for 4:3 or something, but it looks silly on 16:9(1080p) .
