### PR TITLE
Proper Subtitle Support

### DIFF
--- a/hud_src/scripts/hudlayout.res
+++ b/hud_src/scripts/hudlayout.res
@@ -568,7 +568,7 @@
 		"tall"		"100"	[$WIN32]
 		"tall"		"100"	[$X360]
 
-		"BgAlpha"	"75"
+		"BgAlpha"	"100"
 
 		"GrowTime"		"0.25"
 		"ItemHiddenTime"	"0.2"  // Nearly same as grow time so that the item doesn't start to show until growth is finished

--- a/hud_src/scripts/hudlayout.res
+++ b/hud_src/scripts/hudlayout.res
@@ -561,14 +561,14 @@
 		"fieldName" "HudCloseCaption"
 		"visible"	"1"
 		"enabled"	"1"
-		"xpos"		"c-250"
-		"ypos"		"276"	[$WIN32]
-		"ypos"		"236"	[$X360]
-		"wide"		"500"
-		"tall"		"136"	[$WIN32]
-		"tall"		"176"	[$X360]
+		"xpos"		"c215"
+		"ypos"		"330"	[$WIN32]
+		"ypos"		"330"	[$X360]
+		"wide"		"200"
+		"tall"		"100"	[$WIN32]
+		"tall"		"100"	[$X360]
 
-		"BgAlpha"	"128"
+		"BgAlpha"	"75"
 
 		"GrowTime"		"0.25"
 		"ItemHiddenTime"	"0.2"  // Nearly same as grow time so that the item doesn't start to show until growth is finished


### PR DESCRIPTION
[Subtitles](http://steamcommunity.com/sharedfiles/filedetails/?id=167785751) now go into the bottom-right corner, on your viewmodel,
**After:**
![2016-03-05_00018](https://cloud.githubusercontent.com/assets/12103418/13550213/406f2c4e-e2de-11e5-8fd4-ea1e4423d1cf.jpg)

instead of normally being in the middle, being covered the the other HUD elements.
**Before:**
![2016-03-05_00067](https://cloud.githubusercontent.com/assets/12103418/13550270/8d15a7ca-e2df-11e5-820b-07868005cd0e.jpg)


Subtitles don't interfere with the other HUD elements anymore.