### PR TITLE
TargetID and Spectator mode fixes

### DIFF
--- a/hud_src/resource/ui/hudinspectpanel.res
+++ b/hud_src/resource/ui/hudinspectpanel.res
@@ -1,0 +1,59 @@
+"Resource/UI/HudInspectPanel.res"
+{	
+	"itempanel"
+	{
+		"ControlName"	"CItemModelPanel"
+		"fieldName"		"itempanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"zpos"			"10"
+		"wide"			"190"
+		"tall"			"100"
+		"visible"		"0"
+		"bgcolor_override"		"255 255 255 0"
+		"PaintBackgroundType"	"0"
+		
+		"model_ypos"		"20"
+		"model_center_x"	"1"
+		"model_wide"		"80"
+		"model_tall"		"50"
+		
+		"text_xpos"		"10"
+		"text_ypos"		"10"
+		"text_wide"		"170"
+		"text_center"	"1"
+		
+		"max_text_height"	"100"
+		"padding_height"	"10"
+		"resize_to_text"	"1"
+		"text_forcesize"	"2"
+		
+		"itemmodelpanel"
+		{
+			"fieldName"		"itemmodelpanel"
+			"use_item_rendertarget" "0"
+			"useparentbg"		"1"
+			"inventory_image_type"	"1"
+		}
+		
+		"ItemLabel"
+		{	
+			"ControlName"	"Label"
+			"fieldName"		"ItemLabel"
+			"font"			"DefaultSmall"
+			"xpos"			"10"
+			"ypos"			"3"
+			"zpos"			"1"
+			"wide"			"270"
+			"tall"			"9"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"labelText"		"#FreezePanel_Item"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+	}	
+}

--- a/hud_src/resource/ui/hudobjectivearenahybrid.res
+++ b/hud_src/resource/ui/hudobjectivearenahybrid.res
@@ -1,0 +1,185 @@
+#base "HudObjectivePlayerDestruction.res"
+
+"Resource/UI/HudObjectiveArenaHybrid.res"
+{
+	"blueteam"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"blueteam"
+		"xpos"			"c-56"
+		"ypos"			"21"
+		"zpos"			"0"
+		"wide"			"60"
+		"tall"			"30"
+		"visible"		"1"
+	
+		"background"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"background"
+			"xpos"			"5"
+			"ypos"			"7"
+			"zpos"			"0"
+			"wide"			"50"
+			"tall"			"23"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"../hud/color_panel_blu"
+				
+			"src_corner_height"		"23"			// pixels inside the image
+			"src_corner_width"		"23"
+					
+			"draw_corner_width"		"5"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"5"	
+		}
+		
+		"count"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"count"
+			"xpos"			"23"
+			"ypos"			"7"
+			"zpos"			"2"
+			"wide"			"30"
+			"tall"			"25"
+			"autoResize"	"1"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"font"			"HudFontMedium"
+			//"labelText"		"%blue_alive%"
+			//"labelText"		"%blue_escrow%"
+			"labelText"		" "
+			"textAlignment"	"center"
+			"fgcolor"		"TanLight"
+		}	
+		"countshadow"
+		{
+			"ControlName"		"CExLabel"
+			"fieldName"		"countshadow"
+			"xpos"			"24"
+			"ypos"			"8"
+			"zpos"			"1"
+			"wide"			"30"
+			"tall"			"25"
+			"autoResize"	"1"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"font"			"HudFontMedium"
+			//"labelText"		"%blue_alive%"
+			//"labelText"		"%blue_escrow%"
+			"labelText"		" "
+			"textAlignment"	"center"
+			"fgcolor"		"Black"
+		}
+		
+		"playerimage"
+		{
+			"ControlName"	"ImagePanel"		
+			"fieldName"		"playerimage"
+			"xpos"			"12"
+			"ypos"			"10"
+			"zpos"			"3"
+			"wide"			"8"
+			"tall"			"16"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"capture_icon_white"
+			"scaleImage"	"1"
+		}
+	}
+
+	"redteam"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"redteam"
+		"xpos"			"c-4"
+		"ypos"			"21"
+		"zpos"			"0"
+		"wide"			"60"
+		"tall"			"30"
+		"visible"		"1"
+	
+		"background"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"background"
+			"xpos"			"5"
+			"ypos"			"7"
+			"zpos"			"0"
+			"wide"			"50"
+			"tall"			"23"
+			"autoResize"	"1"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"../hud/color_panel_red"
+				
+			"src_corner_height"		"23"			// pixels inside the image
+			"src_corner_width"		"23"
+					
+			"draw_corner_width"		"5"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"5"	
+		}
+		
+		"count"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"count"
+			"xpos"			"23"
+			"ypos"			"7"
+			"zpos"			"2"
+			"wide"			"30"
+			"tall"			"25"
+			"autoResize"	"1"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"font"			"HudFontMedium"
+			//"labelText"		"%red_alive%"
+			//"labelText"		"%red_escrow%"
+			"labelText"		" "
+			"textAlignment"	"center"
+			"fgcolor"		"TanLight"
+		}	
+		
+		"countshadow"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"countshadow"
+			"xpos"			"24"
+			"ypos"			"8"
+			"zpos"			"1"
+			"wide"			"30"
+			"tall"			"25"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"font"			"HudFontMedium"
+			//"labelText"		"%red_alive%"
+			//"labelText"		"%red_escrow%"
+			"labelText"		" "
+			"textAlignment"	"center"
+			"fgcolor"		"Black"
+		}
+	
+		"playerimage"
+		{
+			"ControlName"	"ImagePanel"		
+			"fieldName"		"playerimage"
+			"xpos"			"12"
+			"ypos"			"10"
+			"zpos"			"3"
+			"wide"			"8"
+			"tall"			"16"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"capture_icon_white"
+			"scaleImage"	"1"
+		}			
+	}
+}

--- a/hud_src/resource/ui/spectator.res
+++ b/hud_src/resource/ui/spectator.res
@@ -104,9 +104,9 @@
 		"ControlName"		"CExLabel"
 		"fieldName"		"MapLabel"
 		"font"			"HudFontSpectator"
-		"xpos"			"r260"	[$WIN32]
-		"ypos"			"r23"	[$WIN32]
-		"wide"			"240"	[$WIN32]
+		"xpos"			"r260"
+		"ypos"			"r16"
+		"wide"			"240"
 		"tall"			"20"
 		"tall_hidef"		"30"
 		"autoResize"		"0"

--- a/hud_src/resource/ui/spectator.res
+++ b/hud_src/resource/ui/spectator.res
@@ -105,11 +105,8 @@
 		"fieldName"		"MapLabel"
 		"font"			"HudFontSpectator"
 		"xpos"			"r260"	[$WIN32]
-		"ypos"			"r16"	[$WIN32]
-		"xpos"			"r285"	[$X360]
-		"ypos"			"32"	[$X360]
+		"ypos"			"r23"	[$WIN32]
 		"wide"			"240"	[$WIN32]
-		"wide"			"220"	[$X360]
 		"tall"			"20"
 		"tall_hidef"		"30"
 		"autoResize"		"0"
@@ -256,7 +253,7 @@
 	{
 		"ControlName"		"CExLabel"
 		"fieldName"		"TipLabel"
-		"xpos"			"20"
+		"xpos"			"31"
 		"ypos"			"r60"
 		"zpos"			"2"
 		"wide"			"160"
@@ -330,6 +327,7 @@
 			"fieldName"		"itemmodelpanel"
 			"use_item_rendertarget" "0"
 			"useparentbg"		"1"
+			"inventory_image_type"	"1"
 		}
 
 		"ItemLabel"

--- a/hud_src/resource/ui/spectator.res
+++ b/hud_src/resource/ui/spectator.res
@@ -271,29 +271,6 @@
 		"wrap"			"1"
 		"fgcolor"		"White"
 	}
-	"TipLabel2"
-	{
-		"ControlName"		"CExLabel"
-		"fieldName"		"TipLabel2"
-		"xpos"			"21"
-		"ypos"			"r59"
-		"zpos"			"1"
-		"wide"			"160"
-		"tall"			"54"
-		"autoResize"		"0"
-		"pinCorner"		"0"
-		"visible"		"1"
-		"enabled"		"1"
-		"labelText"		"%tip%"
-		"textAlignment"		"center"	[$WIN32]
-		"textAlignment"		"north-west"	[$X360]
-		"font"			"SpectatorKeyHints"
-		"font_hidef"	"HudFontSmall"
-		"font_lodef"	"DefaultVerySmall"
-		"wrap"			"1"
-		"fgcolor"		"Black"
-	}
-
 	"itempanel"
 	{
 		"ControlName"	"CItemModelPanel"

--- a/hud_src/scripts/hudlayout.res
+++ b/hud_src/scripts/hudlayout.res
@@ -244,7 +244,7 @@
 		"visible" 	"0"
 		"enabled" 	"1"
 		"xpos"		"c-126"
-		"ypos"		"355"
+		"ypos"		"335"
 		"wide"	 	"252"
 		"tall"	 	"28"
 		"priority"	"40"

--- a/hud_src/scripts/hudlayout.res
+++ b/hud_src/scripts/hudlayout.res
@@ -225,7 +225,7 @@
 		"visible" 	"0"
 		"enabled" 	"1"
 		"xpos"		"c-126"
-		"ypos"		"355"
+		"ypos"		"335"
 		"wide"	 	"252"
 		"tall"	 	"28"
 		"priority"	"40"
@@ -257,7 +257,7 @@
 		"visible" 	"0"
 		"enabled" 	"1"
 		"xpos"		"c-126"
-		"ypos"		"380"
+		"ypos"		"365"
 		"wide"	 	"252"
 		"tall"	 	"28"
 		"priority"	"35"
@@ -445,9 +445,8 @@
 		"visible" "1"
 		"enabled" "1"
 		"xpos"	 "r640"	[$WIN32]
-		"ypos"	 "18"	[$WIN32]
+		"ypos"	 "35"	[$WIN32]
 		"xpos"	 "r672"	[$X360]
-		"ypos"	 "35"	[$X360]
 		"wide"	 "628"
 		"tall"	 "468"
 


### PR DESCRIPTION
- Fixed a black bar above warpainted weapons on 1440p resolutions: https://github.com/CriticalFlaw/TF2HUD.Fixes/issues/155
- Fixed some targetID overlaps in spectator mode
- Fixed some inconsistencies in spectator mode (tip text shadow, improper alignment)
- Updated item inspect panel to use high-quality item images

BEFORE:
![20240101213535_1](https://github.com/TheKins/frankenhud/assets/50501742/88f56148-dfdf-4029-b287-a317e545f3c2)

AFTER:
![20240101213934_1](https://github.com/TheKins/frankenhud/assets/50501742/c74739ad-2699-446d-9b0e-ab19832482b6)


