### PR TITLE
Scoreboard adjustments

### DIFF
--- a/hud_src/resource/ui/scoreboard.res
+++ b/hud_src/resource/ui/scoreboard.res
@@ -200,7 +200,7 @@
 		"labelText"		"%blueteamplayercount%"
 		"textAlignment"		"center"
 		"xpos"			"70"
-		"ypos"			"42"
+		"ypos"			"39"
 		"wide"			"130"
 		"tall"			"20"
 		"autoResize"		"0"
@@ -287,7 +287,7 @@
 		"labelText"		"%redteamplayercount%"
 		"textAlignment"		"center"
 		"xpos"			"441"
-		"ypos"			"42"
+		"ypos"			"39"
 		"wide"			"130"
 		"tall"			"20"
 		"autoResize"		"0"
@@ -437,10 +437,10 @@
 		"ControlName"	"SectionedListPanel"
 		"fieldName"		"BluePlayerList"
 		"xpos"			"5"
-		"ypos"			"55"
+		"ypos"			"57"
 		"zpos"			"20"
 		"wide"			"310"
-		"tall"			"298"
+		"tall"			"300"
 		"pinCorner"		"0"
 		"visible"		"1"
 		"enabled"		"1"
@@ -461,10 +461,10 @@
 		"ControlName"	"SectionedListPanel"
 		"fieldName"		"RedPlayerList"
 		"xpos"			"325"
-		"ypos"			"55"
+		"ypos"			"57"
 		"zpos"			"20"
 		"wide"			"310"
-		"tall"			"298"
+		"tall"			"300"
 		"pinCorner"		"0"
 		"visible"		"1"
 		"enabled"		"1"
@@ -572,12 +572,12 @@
 	{
 		"ControlName"		"ImagePanel"
 		"fieldName"		"ClassImage"
-		"xpos"			"22"
+		"xpos"			"18"
 		"xpos_lodef"	"12"
-		"ypos"			"350"
+		"ypos"			"364"
 		"zpos"			"3"
-		"wide"			"92"
-		"tall"			"92"
+		"wide"			"80"
+		"tall"			"80"
 		"visible"		"0"
 		"enabled"		"1"
 		"image"			"../hud/class_scoutred"
@@ -593,19 +593,19 @@
 		"ControlName"	"CTFPlayerModelPanel"
 		"fieldName"		"classmodelpanel"
 
-		"xpos"			"-10"
-		"ypos"			"185"
+		"xpos"			"5"
+		"ypos"			"250"
 		"zpos"			"10"
-		"wide"			"130"
-		"tall"			"260"
+		"wide"			"120"
+		"tall"			"195"
 		"autoResize"	"0"
 		"pinCorner"		"0"
 		"visible"		"0"
 		"enabled"		"1"
 
 		"render_texture"	"0"
-		"fov"			"12"
-		"allow_rot"		"1"
+		"fov"			"20"
+		"allow_rot"		"0"
 
 		"disable_speak_event"	"1"
 
@@ -619,166 +619,17 @@
 			"force_pos"	"1"
 
 			"angles_x" "0"
-			"angles_y" "172"
+			"angles_y" "165"
 			"angles_z" "0"
 			"origin_x" "200"
 			"origin_y" "0"
-			"origin_z" "-60"
+			"origin_z" "-90"
 			"frame_origin_x"	"0"
 			"frame_origin_y"	"0"
 			"frame_origin_z"	"0"
 			"spotlight" "1"
 
 			"modelname"		""
-
-			"animation"
-			{
-				"name"		"PRIMARY"
-				"activity"	"ACT_MP_STAND_PRIMARY"
-				"default"	"1"
-			}
-			"animation"
-			{
-				"name"		"SECONDARY"
-				"activity"	"ACT_MP_STAND_SECONDARY"
-			}
-			"animation"
-			{
-				"name"		"MELEE"
-				"activity"	"ACT_MP_STAND_MELEE"
-			}
-			"animation"
-			{
-				"name"		"BUILDING"
-				"activity"	"ACT_MP_STAND_BUILDING"
-			}
-			"animation"
-			{
-				"name"		"PDA"
-				"activity"	"ACT_MP_STAND_PDA"
-			}
-			"animation"
-			{
-				"name"		"ITEM1"
-				"activity"	"ACT_MP_STAND_ITEM1"
-			}
-			"animation"
-			{
-				"name"		"ITEM2"
-				"activity"	"ACT_MP_STAND_ITEM2"
-			}
-			"animation"
-			{
-				"name"		"MELEE_ALLCLASS"
-				"activity"	"ACT_MP_STAND_MELEE_ALLCLASS"
-			}
-			"animation"
-			{
-				"name"		"PRIMARY2"
-				"activity"	"ACT_MP_STAND_PRIMARY"
-			}
-			"animation"
-			{
-				"name"		"SECONDARY2"
-				"activity"	"ACT_MP_STAND_SECONDARY2"
-			}
-		}
-
-		"customclassdata"
-		{
-			"undefined"
-			{
-			}
-			"Scout"
-			{
-				"fov"			"25"
-				"angles_x"		"-17"
-				"angles_y"		"145"
-				"angles_z"		"0"
-				"origin_x"		"105"
-				"origin_y"		"4"
-				"origin_z"		"-82"
-			}
-			"Sniper"
-			{
-				"fov"			"25"
-				"angles_x"		"-10"
-				"angles_y"		"172"
-				"angles_z"		"0"
-				"origin_x"		"130"
-				"origin_y"		"-3"
-				"origin_z"		"-97"
-			}
-			"Soldier"
-			{
-				"fov"			"25"
-				"angles_x"		"-10"
-				"angles_y"		"170"
-				"angles_z"		"0"
-				"origin_x"		"145"
-				"origin_y"		"-5"
-				"origin_z"		"-90"
-			}
-			"Demoman"
-			{
-				"fov"			"25"
-				"angles_x"		"-13"
-				"angles_y"		"200"
-				"angles_z"		"0"
-				"origin_x"		"138"
-				"origin_y"		"-4"
-				"origin_z"		"-93"
-			}
-			"Medic"
-			{
-				"fov"			"20"
-				"angles_x"		"-5"
-				"angles_y"		"178"
-				"angles_z"		"0"
-				"origin_x"		"150"
-				"origin_y"		"-5"
-				"origin_z"		"-96"
-			}
-			"Heavy"
-			{
-				"fov"			"20"
-				"angles_x"		"-5"
-				"angles_y"		"200"
-				"angles_z"		"0"
-				"origin_x"		"200"
-				"origin_y"		"0"
-				"origin_z"		"-102"
-			}
-			"Pyro"
-			{
-				"fov"			"20"
-				"angles_x"		"-5"
-				"angles_y"		"172"
-				"angles_z"		"0"
-				"origin_x"		"175"
-				"origin_y"		"-5"
-				"origin_z"		"-90"
-			}
-			"Spy"
-			{
-				"fov"			"20"
-				"angles_x"		"-5"
-				"angles_y"		"160"
-				"angles_z"		"0"
-				"origin_x"		"160"
-				"origin_y"		"0"
-				"origin_z"		"-95"
-			}
-			"Engineer"
-			{
-				"fov"			"20"
-				"angles_x"		"-10"
-				"angles_y"		"168"
-				"angles_z"		"0"
-				"origin_x"		"140"
-				"origin_y"		"-2"
-				"origin_z"		"-82"
-			}
 		}
 	}
 	"PlayerNameBG"


### PR DESCRIPTION
- Fixed player model increasing in size when using hud_reloadscheme
- Fixed some text being cut off (e.g player count label)
- Fixed some overlapping
- Reduced size of the class image and playermodel (mostly to avoid overlapping)

![20240116135316_1](https://github.com/TheKins/frankenhud/assets/50501742/f8c24922-e61b-4c10-a0a2-5aad80910914)
