### PR TITLE
Consistency update and other fixes

### DIFF
--- a/resource/ui/hud_obj_dispenser.res
+++ b/resource/ui/hud_obj_dispenser.res
@@ -1,0 +1,376 @@
+"Resource/UI/hud_obj_dispenser.res"
+{
+	"BuildingStatusItem"
+	{
+		"ControlName"	"Frame"
+		"fieldName"		"BuildingStatusItem"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"150"
+		"tall"			"31"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	
+	"Background"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Background"
+		"xpos"			"0"
+		"ypos"			"0"
+		"zpos"			"-1"
+		"wide"			"120"
+		"tall"			"31"
+		"visible"		"0"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_background_disabled"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"Icon_Dispenser"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Icon"
+		"xpos"			"24"
+		"ypos"			"1"
+		"wide"			"28"
+		"tall"			"28"
+		"visible"		"1"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_dispenser"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"NotBuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"NotBuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"31"
+		"visible"		"1"
+
+		"NotBuiltLabel"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"NotBuiltLabel"
+			"font"			"HudFontSmallest"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"200"
+			"tall"			"31"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"labelText"		"#Building_hud_dispenser_not_built"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"NotBuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"NotBuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"30"
+			"visible"		"1"
+			"enabled"		"0"
+			"scaleImage"	"1"	
+			"image"			"../hud/color_panel_brown"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+	}
+	
+	"BuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"BuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"31"
+		"visible"		"0"
+
+		"BuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"BuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"30"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"../hud/color_panel_red"
+			"teambg_2"		"../hud/color_panel_red"
+			"teambg_3"		"../hud/color_panel_blu"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+
+		"Icon_Upgrade_1"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_1"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_1"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Icon_Upgrade_2"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_2"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_2"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Icon_Upgrade_3"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_3"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_3"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"AlertTray"
+		{
+			"ControlName"	"CBuildingStatusAlertTray"
+			"fieldName"		"AlertTray"
+			"xpos"			"115"
+			"ypos"			"-1"
+			"wide"			"34"
+			"tall"			"32"
+			"visible"		"1"
+			"enabled"		"1"	
+			"icon"			"obj_status_alert_background"
+		}
+
+		"WrenchIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"WrenchIcon"
+			"xpos"			"122"
+			"ypos"			"6"
+			"zpos"			"1"
+			"wide"			"19"
+			"tall"			"19"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_wrench"
+			"iconColor"		"Black"
+		}
+		
+		"SapperIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"SapperIcon"
+			"xpos"			"122"
+			"ypos"			"3"
+			"zpos"			"1"
+			"wide"			"21"
+			"tall"			"21"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_sapper"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Health"
+		{	
+			"ControlName"	"CBuildingHealthBar"
+			"fieldName"		"Health"
+			"font"			"Default"
+			"xpos"			"13"
+			"ypos"			"3"
+			"wide"			"8"
+			"tall"			"24"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"BuildingPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"BuildingPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"31"
+			"visible"		"0"
+
+			"BuildingLabel"
+			{
+				"ControlName"	"CExLabel"
+				"fieldName"		"BuildingLabel"
+				"font"			"HudFontSmallest"
+				"xpos"			"0"
+				"ypos"			"4"
+				"wide"			"200"
+				"tall"			"12"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"labelText"		"#Building_hud_building"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+			
+			"BuildingProgress"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"BuildingProgress"
+				"font"			"Default"
+				"xpos"			"0"
+				"ypos"			"16"
+				"wide"			"50"
+				"tall"			"8"				
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	
+		"RunningPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"RunningPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"31"
+			"visible"		"0"
+			
+			"AmmoIcon"	
+			{
+				"ControlName"	"ImagePanel"
+				"fieldName"		"AmmoIcon"
+				"xpos"			"0"
+				"ypos"			"5"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"
+				"image"			"../hud/hud_obj_status_ammo_64"
+				"drawcolor"		"ProgressOffWhite"
+			}
+
+			"Ammo"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"Ammo"
+				"font"			"Default"
+				"xpos"			"12"
+				"ypos"			"6"
+				"wide"			"38"
+				"tall"			"8"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}	
+			
+			"UpgradeIcon"
+			{
+				"ControlName"	"CIconPanel"
+				"fieldName"		"UpgradeIcon"
+				"xpos"			"0"
+				"ypos"			"16"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"	
+				"icon"			"ico_metal"
+				"iconColor"		"ProgressOffWhite"
+			}
+			
+			"Upgrade"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"Upgrade"
+				"font"			"Default"
+				"xpos"			"12"
+				"ypos"			"17"
+				"wide"			"38"
+				"tall"			"8"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	}
+}

--- a/resource/ui/hud_obj_sapper.res
+++ b/resource/ui/hud_obj_sapper.res
@@ -1,0 +1,248 @@
+"Resource/UI/hud_obj_sapper.res"
+{
+	"BuildingStatusItem"
+	{
+		"ControlName"	"Frame"
+		"fieldName"		"BuildingStatusItem"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"150"
+		"tall"			"31"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	
+	"Background"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Background"
+		"xpos"			"0"
+		"ypos"			"0"
+		"zpos"			"-1"
+		"wide"			"120"
+		"tall"			"31"
+		"visible"		"0"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_background_red"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"Icon"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Icon"
+		"xpos"			"24"
+		"ypos"			"1"
+		"wide"			"28"
+		"tall"			"28"
+		"visible"		"1"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_sapper"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"NotBuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"NotBuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"31"
+		"visible"		"1"
+
+		"NotBuiltLabel"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"NotBuiltLabel"
+			"font"			"DefaultSmall"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"200"
+			"tall"			"31"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"labelText"		"#Building_hud_sapper_not_built"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"NotBuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"NotBuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"30"
+			"visible"		"1"
+			"enabled"		"0"
+			"scaleImage"	"1"	
+			"image"			"../hud/color_panel_brown"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+	}
+	
+	"BuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"BuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"43"
+		"visible"		"0"
+
+		"BuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"BuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"30"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"../hud/color_panel_red"
+			"teambg_2"		"../hud/color_panel_red"
+			"teambg_3"		"../hud/color_panel_blu"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+
+		"Health"
+		{	
+			"ControlName"	"CBuildingHealthBar"
+			"fieldName"		"Health"
+			"font"			"Default"
+			"xpos"			"13"
+			"ypos"			"2"
+			"wide"			"8"
+			"tall"			"24"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"BuildingPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"BuildingPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"31"
+			"visible"		"0"
+
+			"BuildingLabel"
+			{
+				"ControlName"	"CExLabel"
+				"fieldName"		"BuildingLabel"
+				"font"			"DefaultSmall"
+				"xpos"			"0"
+				"ypos"			"5"
+				"wide"			"200"
+				"tall"			"12"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"labelText"		"#Building_hud_building"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+			
+			"BuildingProgress"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"BuildingProgress"
+				"font"			"Default"
+				"xpos"			"0"
+				"ypos"			"16"
+				"wide"			"50"
+				"tall"			"8"				
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	
+		"RunningPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"RunningPanel"
+			"xpos"			"55"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"31"
+			"visible"		"0"
+			
+			"TargetIcon"
+			{
+				"ControlName"	"CIconPanel"
+				"fieldName"		"TargetIcon"
+				"xpos"			"0"
+				"ypos"			"5"
+				"wide"			"20"
+				"tall"			"20"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"	
+				"icon"			"obj_status_sentrygun_1"
+				"iconColor"		"255 255 255 255"
+			}
+			
+			"TargetHealth"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"TargetHealth"
+				"font"			"Default"
+				"xpos"			"22"
+				"ypos"			"12"
+				"wide"			"35"
+				"tall"			"8"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	}
+}

--- a/resource/ui/hud_obj_sentrygun.res
+++ b/resource/ui/hud_obj_sentrygun.res
@@ -1,0 +1,477 @@
+"Resource/UI/hud_obj_sentrygun.res"
+{
+	"BuildingStatusItem"
+	{
+		"ControlName"	"Frame"
+		"fieldName"		"BuildingStatusItem"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"60"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	
+	"Background"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Background"
+		"xpos"			"0"
+		"ypos"			"0"
+		"zpos"			"-1"
+		"wide"			"120"
+		"tall"			"60"
+		"visible"		"0"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_background_tall_disabled"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"Icon_Sentry_1"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Icon_Sentry_1"
+		"xpos"			"22"
+		"ypos"			"12"
+		"wide"			"36"
+		"tall"			"36"
+		"visible"		"1"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_sentrygun_1"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"Icon_Sentry_2"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Icon_Sentry_2"
+		"xpos"			"22"
+		"ypos"			"12"
+		"wide"			"36"
+		"tall"			"36"
+		"visible"		"0"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_sentrygun_2"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"Icon_Sentry_3"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Icon_Sentry_3"
+		"xpos"			"22"
+		"ypos"			"12"
+		"wide"			"36"
+		"tall"			"36"
+		"visible"		"0"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_sentrygun_3"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"NotBuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"NotBuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"60"
+		"visible"		"1"
+
+		"NotBuiltLabel"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"NotBuiltLabel"
+			"font"			"HudFontSmallest"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"200"
+			"tall"			"60"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"labelText"		"#Building_hud_sentry_not_built"
+			"labelText_lodef"		"#Building_hud_sentry_not_built_360"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"NotBuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"NotBuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"58"
+			"visible"		"1"
+			"enabled"		"0"
+			"scaleImage"	"1"	
+			"image"			"../hud/color_panel_brown"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+	}
+	
+	"BuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"BuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"60"
+		"visible"		"0"
+		
+		"BuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"BuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"58"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"../hud/color_panel_red"
+			"teambg_2"		"../hud/color_panel_red"
+			"teambg_3"		"../hud/color_panel_blu"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+
+		"Icon_Upgrade_1"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_1"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_1"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Icon_Upgrade_2"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_2"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_2"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Icon_Upgrade_3"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_3"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_3"
+			"iconColor"		"255 255 255 255"
+		}
+		
+		"AlertTray"
+		{
+			"ControlName"	"CBuildingStatusAlertTray"
+			"fieldName"		"AlertTray"
+			"xpos"			"114"
+			"ypos"			"0"
+			"zpos"			"-2"
+			"wide"			"44"
+			"tall"			"60"
+			"visible"		"1"
+			"enabled"		"1"	
+			"icon"			"obj_status_alert_background_tall"
+		}
+		
+		"WrenchIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"WrenchIcon"
+			"xpos"			"125"
+			"ypos"			"20"
+			"zpos"			"1"
+			"wide"			"23"
+			"tall"			"23"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_wrench"
+			"iconColor"		"Black"
+		}
+		
+		"SapperIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"SapperIcon"
+			"xpos"			"125"
+			"ypos"			"19"
+			"zpos"			"1"
+			"wide"			"23"
+			"tall"			"23"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_sapper"
+			"iconColor"		"255 255 255 255"
+		}
+		
+		"Health"
+		{	
+			"ControlName"	"CBuildingHealthBar"
+			"fieldName"		"Health"
+			"font"			"Default"
+			"xpos"			"13"
+			"ypos"			"3"
+			"wide"			"8"
+			"tall"			"53"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"	
+		}
+		
+		"BuildingPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"BuildingPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"60"
+			"visible"		"0"
+
+			"BuildingLabel"
+			{
+				"ControlName"	"CExLabel"
+				"fieldName"		"BuildingLabel"
+				"font"			"HudFontSmallest"
+				"xpos"			"0"
+				"ypos"			"17"
+				"wide"			"200"
+				"tall"			"12"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"labelText"		"#Building_hud_building"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+			
+			"BuildingProgress"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"BuildingProgress"
+				"font"			"Default"
+				"xpos"			"0"
+				"ypos"			"29"
+				"wide"			"50"
+				"tall"			"8"				
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+		
+		"RunningPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"RunningPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"60"
+			"visible"		"0"
+			
+			"KillIcon"	
+			{
+				"ControlName"	"ImagePanel"
+				"fieldName"		"KillIcon"
+				"xpos"			"0"
+				"ypos"			"12"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"
+				"image"			"../hud/hud_obj_status_kill_64"
+				"drawcolor"		"ProgressOffWhite"
+			}
+						
+			"KillsLabel"
+			{	
+				"ControlName"	"CExLabel"
+				"fieldName"		"KillsLabel"
+				"font"			"DefaultSmall"
+				"xpos"			"12"
+				"ypos"			"13"
+				"wide"			"200"
+				"tall"			"22"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"labelText"		"#Building_hud_sentry_kills_assists"
+				"textAlignment"	"north-west"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+					
+			"ShellIcon"	
+			{
+				"ControlName"	"ImagePanel"
+				"fieldName"		"ShellIcon"
+				"xpos"			"0"
+				"ypos"			"25"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"
+				"image"			"../hud/hud_obj_status_ammo_64"
+				"drawcolor"		"ProgressOffWhite"
+			}
+			
+			"Shells"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"Shells"
+				"font"			"Default"
+				"xpos"			"12"
+				"ypos"			"26"
+				"wide"			"38"
+				"tall"			"8"				
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+			
+			"RocketIcon"	
+			{
+				"ControlName"	"ImagePanel"
+				"fieldName"		"RocketIcon"
+				"xpos"			"0"
+				"ypos"			"38"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"0"
+				"enabled"		"1"
+				"scaleImage"	"1"
+				"image"			"../hud/hud_obj_status_rockets_64"
+				"drawcolor"		"ProgressOffWhite"
+			}
+			
+			"Rockets"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"Rockets"
+				"font"			"Default"
+				"xpos"			"12"
+				"ypos"			"39"
+				"wide"			"38"
+				"tall"			"8"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"0"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+
+			"UpgradeIcon"
+			{
+				"ControlName"	"CIconPanel"
+				"fieldName"		"UpgradeIcon"
+				"xpos"			"0"
+				"ypos"			"38"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"	
+				"icon"			"ico_metal"
+				"iconColor"		"ProgressOffWhite"
+			}			
+			
+			"Upgrade"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"Upgrade"
+				"font"			"Default"
+				"xpos"			"12"
+				"ypos"			"39"
+				"wide"			"38"
+				"tall"			"8"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	}
+}

--- a/resource/ui/hud_obj_sentrygun_disp.res
+++ b/resource/ui/hud_obj_sentrygun_disp.res
@@ -1,0 +1,330 @@
+"Resource/UI/hud_obj_sentrygun_disp.res"
+{
+	"BuildingStatusItem"
+	{
+		"ControlName"	"Frame"
+		"fieldName"		"BuildingStatusItem"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"22"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	
+	"Background"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Background"
+		"xpos"			"0"
+		"ypos"			"0"
+		"zpos"			"-1"
+		"wide"			"120"
+		"tall"			"22"
+		"visible"		"0"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_background_disabled"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"Icon_Sentry_1"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Icon_Sentry_1"
+		"xpos"			"30"
+		"ypos"			"1"
+		"wide"			"15"
+		"tall"			"15"
+		"visible"		"1"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_sentrygun_1"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"NotBuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"NotBuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"20"
+		"visible"		"1"
+
+		"NotBuiltLabel"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"NotBuiltLabel"
+			"font"			"DefaultVerySmall"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"200"
+			"tall"			"20"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"labelText"		"#Building_hud_disp_sentry_not_built"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"NotBuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"NotBuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"20"
+			"visible"		"1"
+			"enabled"		"0"
+			"scaleImage"	"1"	
+			"image"			"../hud/color_panel_brown"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+	}
+	
+	"BuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"BuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"20"
+		"visible"		"0"
+
+		"BuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"BuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"20"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"../hud/color_panel_red"
+			"teambg_2"		"../hud/color_panel_red"
+			"teambg_3"		"../hud/color_panel_blu"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+		
+		"Icon_Upgrade_1"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_1"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"0"
+			"scaleImage"	"1"	
+			"icon"			""
+			"iconColor"		"255 255 255 255"
+		}
+	
+		"AlertTray"
+		{
+			"ControlName"	"CBuildingStatusAlertTray"
+			"fieldName"		"AlertTray"
+			"xpos"			"9999"
+		}
+
+		"WrenchIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"WrenchIcon"
+			"xpos"			"9999"
+		}
+		
+		"SapperIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"SapperIcon"
+			"xpos"			"117"
+			"ypos"			"12"
+			"zpos"			"1"
+			"wide"			"15"
+			"tall"			"15"
+			"visible"		"0"
+			"enabled"		"0"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_sapper"
+			"iconColor"		"255 255 255 255"
+		}
+		
+		"Health"
+		{	
+			"ControlName"	"CBuildingHealthBar"
+			"fieldName"		"Health"
+			"font"			"Default"
+			"xpos"			"13"
+			"ypos"			"4"
+			"wide"			"8"
+			"tall"			"15"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"	
+		}
+		
+		"BuildingPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"BuildingPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"30"
+			"visible"		"0"
+
+			"BuildingLabel"
+			{
+				"ControlName"	"CExLabel"
+				"fieldName"		"BuildingLabel"
+				"font"			"DefaultSmall"
+				"xpos"			"0"
+				"ypos"			"17"
+				"wide"			"200"
+				"tall"			"12"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"labelText"		"#Building_hud_building"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+			
+			"BuildingProgress"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"BuildingProgress"
+				"font"			"Default"
+				"xpos"			"0"
+				"ypos"			"29"
+				"wide"			"50"
+				"tall"			"8"				
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+		
+		"RunningPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"RunningPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"20"
+			"visible"		"0"
+			
+			"KillIcon"	
+			{
+				"ControlName"	"ImagePanel"
+				"fieldName"		"KillIcon"
+				"xpos"			"0"
+				"ypos"			"5"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"0"
+				"enabled"		"0"
+				"scaleImage"	"1"
+				"image"			"../hud/hud_obj_status_kill_64"
+				"drawcolor"		"ProgressOffWhite"
+			}
+						
+			"KillsLabel"
+			{	
+				"ControlName"	"CExLabel"
+				"fieldName"		"KillsLabel"
+				"font"			"DefaultSmall"
+				"xpos"			"12"
+				"ypos"			"6"
+				"wide"			"200"
+				"tall"			"22"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"0"
+				"enabled"		"0"
+				"labelText"		"#Building_hud_sentry_kills_assists"
+				"textAlignment"	"north-west"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+					
+			"ShellIcon"	
+			{
+				"ControlName"	"ImagePanel"
+				"fieldName"		"ShellIcon"
+				"xpos"			"0"
+				"ypos"			"6"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"
+				"image"			"../hud/hud_obj_status_ammo_64"
+				"drawcolor"		"ProgressOffWhite"
+			}
+			
+			"Shells"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"Shells"
+				"font"			"Default"
+				"xpos"			"12"
+				"ypos"			"7"
+				"wide"			"38"
+				"tall"			"8"				
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	}
+}

--- a/resource/ui/hud_obj_tele_entrance.res
+++ b/resource/ui/hud_obj_tele_entrance.res
@@ -1,0 +1,418 @@
+"Resource/UI/hud_obj_tele_entrance.res"
+{
+	"BuildingStatusItem"
+	{
+		"ControlName"	"Frame"
+		"fieldName"		"BuildingStatusItem"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"150"
+		"tall"			"31"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	
+	"Background"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Background"
+		"xpos"			"0"
+		"ypos"			"0"
+		"zpos"			"-1"
+		"wide"			"120"
+		"tall"			"31"
+		"visible"		"0"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_background_disabled"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"Icon_Teleport_Entrance"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Icon"
+		"xpos"			"24"
+		"ypos"			"1"
+		"wide"			"28"
+		"tall"			"28"
+		"visible"		"1"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_tele_entrance"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"NotBuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"NotBuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"31"
+		"visible"		"1"
+
+		"NotBuiltLabel"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"NotBuiltLabel"
+			"font"			"HudFontSmallest"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"200"
+			"tall"			"31"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"labelText"		"#Building_hud_tele_enter_not_built_360"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"NotBuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"NotBuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"30"
+			"visible"		"1"
+			"enabled"		"0"
+			"scaleImage"	"1"	
+			"image"			"../hud/color_panel_brown"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+	}
+	
+	"BuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"BuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"31"
+		"visible"		"0"
+
+		"BuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"BuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"30"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"../hud/color_panel_red"
+			"teambg_2"		"../hud/color_panel_red"
+			"teambg_3"		"../hud/color_panel_blu"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+
+		"Icon_Upgrade_1"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_1"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_1"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Icon_Upgrade_2"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_2"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_2"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Icon_Upgrade_3"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_3"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_3"
+			"iconColor"		"255 255 255 255"
+		}
+
+
+		"AlertTray"
+		{
+			"ControlName"	"CBuildingStatusAlertTray"
+			"fieldName"		"AlertTray"
+			"xpos"			"115"
+			"ypos"			"-1"
+			"wide"			"34"
+			"tall"			"32"
+			"visible"		"1"
+			"enabled"		"1"	
+			"icon"			"obj_status_alert_background"
+		}
+
+		"WrenchIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"WrenchIcon"
+			"xpos"			"122"
+			"ypos"			"6"
+			"zpos"			"1"
+			"wide"			"19"
+			"tall"			"19"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_wrench"
+			"iconColor"		"Black"
+		}
+		
+		"SapperIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"SapperIcon"
+			"xpos"			"122"
+			"ypos"			"3"
+			"zpos"			"1"
+			"wide"			"21"
+			"tall"			"21"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_sapper"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Health"
+		{	
+			"ControlName"	"CBuildingHealthBar"
+			"fieldName"		"Health"
+			"font"			"Default"
+			"xpos"			"13"
+			"ypos"			"3"
+			"wide"			"8"
+			"tall"			"24"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"BuildingPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"BuildingPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"31"
+			"visible"		"0"
+
+			"BuildingLabel"
+			{
+				"ControlName"	"CExLabel"
+				"fieldName"		"BuildingLabel"
+				"font"			"HudFontSmallest"
+				"xpos"			"0"
+				"ypos"			"4"
+				"wide"			"200"
+				"tall"			"12"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"labelText"		"#Building_hud_building"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+			
+			"BuildingProgress"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"BuildingProgress"
+				"font"			"Default"
+				"xpos"			"0"
+				"ypos"			"16"
+				"wide"			"50"
+				"tall"			"8"				
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	
+		"RunningPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"RunningPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"31"
+			"visible"		"0"
+			
+			"TeleportedIcon"
+			{
+				"ControlName"	"ImagePanel"
+				"fieldName"		"TeleportedIcon"
+				"xpos"			"0"
+				"ypos"			"5"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"image"			"../hud/hud_obj_status_teleport_64"
+				"drawcolor"		"ProgressOffWhite"
+				"scaleImage"	"1"
+			}
+			
+			"ChargingPanel"
+			{
+				"ControlName"	"EditablePanel"
+				"fieldName"		"ChargingPanel"
+				"xpos"			"0"
+				"ypos"			"0"
+				"wide"			"100"
+				"tall"			"31"
+				"visible"		"0"
+				
+				"Recharge"
+				{	
+					"ControlName"	"ContinuousProgressBar"
+					"fieldName"		"Recharge"
+					"font"			"Default"
+					"xpos"			"12"
+					"ypos"			"6"
+					"wide"			"38"
+					"tall"			"8"
+					"autoResize"	"0"
+					"pinCorner"		"0"
+					"visible"		"1"
+					"enabled"		"1"
+					"textAlignment"	"Left"
+					"dulltext"		"0"
+					"brighttext"	"0"
+				}	
+			}
+			
+			"FullyChargedPanel"
+			{
+				"ControlName"	"EditablePanel"
+				"fieldName"		"FullyChargedPanel"
+				"xpos"			"0"
+				"ypos"			"0"
+				"wide"			"100"
+				"tall"			"31"
+				"visible"		"0"
+				
+				"TimesUsedLabel"
+				{	
+					"ControlName"	"CExLabel"
+					"fieldName"		"TimesUsedLabel"
+					"font"			"DefaultSmall"
+					"xpos"			"12"
+					"ypos"			"5"
+					"wide"			"200"
+					"tall"			"25"
+					"autoResize"	"0"
+					"pinCorner"		"0"
+					"visible"		"1"
+					"enabled"		"1"
+					"labelText"		"%timesused%"
+					"textAlignment"	"north-west"
+					"dulltext"		"0"
+					"brighttext"	"0"
+				}
+			}	
+			
+			"UpgradeIcon"
+			{
+				"ControlName"	"CIconPanel"
+				"fieldName"		"UpgradeIcon"
+				"xpos"			"0"
+				"ypos"			"16"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"	
+				"icon"			"ico_metal"
+				"iconColor"		"ProgressOffWhite"
+			}
+			
+			"Upgrade"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"Upgrade"
+				"font"			"Default"
+				"xpos"			"12"
+				"ypos"			"17"
+				"wide"			"38"
+				"tall"			"8"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	}
+}

--- a/resource/ui/hud_obj_tele_exit.res
+++ b/resource/ui/hud_obj_tele_exit.res
@@ -1,0 +1,342 @@
+"Resource/UI/hud_obj_tele_exit.res"
+{
+	"BuildingStatusItem"
+	{
+		"ControlName"	"Frame"
+		"fieldName"		"BuildingStatusItem"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"150"
+		"tall"			"31"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"1"
+		"enabled"		"1"
+		"tabPosition"	"0"
+	}
+	
+	"Background"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Background"
+		"xpos"			"0"
+		"ypos"			"0"
+		"zpos"			"-1"
+		"wide"			"120"
+		"tall"			"31"
+		"visible"		"0"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_background_disabled"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"Icon_Teleport_Exit"
+	{
+		"ControlName"	"CIconPanel"
+		"fieldName"		"Icon"
+		"xpos"			"24"
+		"ypos"			"1"
+		"wide"			"28"
+		"tall"			"28"
+		"visible"		"1"
+		"enabled"		"1"
+		"scaleImage"	"1"	
+		"icon"			"obj_status_tele_exit"
+		"iconColor"		"255 255 255 255"
+	}
+	
+	"NotBuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"NotBuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"31"
+		"visible"		"1"
+
+		"NotBuiltLabel"
+		{
+			"ControlName"	"CExLabel"
+			"fieldName"		"NotBuiltLabel"
+			"font"			"HudFontSmallest"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"200"
+			"tall"			"31"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"labelText"		"#Building_hud_tele_exit_not_built"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"NotBuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"NotBuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"30"
+			"visible"		"1"
+			"enabled"		"0"
+			"scaleImage"	"1"	
+			"image"			"../hud/color_panel_brown"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+	}
+	
+	"BuiltPanel"
+	{
+		"ControlName"	"EditablePanel"
+		"fieldName"		"BuiltPanel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"wide"			"160"
+		"tall"			"43"
+		"visible"		"0"
+
+		"BuiltBg"
+		{
+			"ControlName"	"CTFImagePanel"
+			"fieldName"		"BuiltBg"
+			"xpos"			"0"
+			"ypos"			"0"
+			"zpos"			"-1"
+			"wide"			"120"
+			"tall"			"30"
+			"visible"		"1"
+			"enabled"		"1"
+			"image"			"../hud/color_panel_red"
+			"teambg_2"		"../hud/color_panel_red"
+			"teambg_3"		"../hud/color_panel_blu"
+
+			"scaleImage"			"1"
+			"proportionalToParent"	"1"
+
+			"src_corner_height"		"60"				// pixels inside the image
+			"src_corner_width"		"60"
+
+			"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+			"draw_corner_height" 	"6"
+		}
+
+		"Icon_Upgrade_1"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_1"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_1"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Icon_Upgrade_2"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_2"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_2"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"Icon_Upgrade_3"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"Icon_Upgrade_3"
+			"xpos"			"46"
+			"ypos"			"4"
+			"zpos"			"1"
+			"wide"			"8"
+			"tall"			"8"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_upgrade_3"
+			"iconColor"		"255 255 255 255"
+		}
+
+		"AlertTray"
+		{
+			"ControlName"	"CBuildingStatusAlertTray"
+			"fieldName"		"AlertTray"
+			"xpos"			"115"
+			"ypos"			"-1"
+			"wide"			"34"
+			"tall"			"32"
+			"visible"		"1"
+			"enabled"		"1"	
+			"icon"			"obj_status_alert_background"
+		}
+
+		"WrenchIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"WrenchIcon"
+			"xpos"			"122"
+			"ypos"			"6"
+			"zpos"			"1"
+			"wide"			"19"
+			"tall"			"19"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_wrench"
+			"iconColor"		"Black"
+		}
+		
+		"SapperIcon"
+		{
+			"ControlName"	"CIconPanel"
+			"fieldName"		"SapperIcon"
+			"xpos"			"122"
+			"ypos"			"3"
+			"zpos"			"1"
+			"wide"			"21"
+			"tall"			"21"
+			"visible"		"0"
+			"enabled"		"1"
+			"scaleImage"	"1"	
+			"icon"			"obj_status_icon_sapper"
+			"iconColor"		"255 255 255 255"
+		}
+		
+		"Health"
+		{	
+			"ControlName"	"CBuildingHealthBar"
+			"fieldName"		"Health"
+			"font"			"Default"
+			"xpos"			"13"
+			"ypos"			"3"
+			"wide"			"8"
+			"tall"			"24"
+			"autoResize"	"0"
+			"pinCorner"		"0"
+			"visible"		"1"
+			"enabled"		"1"
+			"textAlignment"	"Left"
+			"dulltext"		"0"
+			"brighttext"	"0"
+		}
+
+		"BuildingPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"BuildingPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"31"
+			"visible"		"0"
+
+			"BuildingLabel"
+			{
+				"ControlName"	"CExLabel"
+				"fieldName"		"BuildingLabel"
+				"font"			"HudFontSmallest"
+				"xpos"			"0"
+				"ypos"			"4"
+				"wide"			"200"
+				"tall"			"12"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"labelText"		"#Building_hud_building"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+			
+			"BuildingProgress"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"BuildingProgress"
+				"font"			"Default"
+				"xpos"			"0"
+				"ypos"			"16"
+				"wide"			"50"
+				"tall"			"8"				
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	
+		"RunningPanel"
+		{
+			"ControlName"	"EditablePanel"
+			"fieldName"		"RunningPanel"
+			"xpos"			"60"
+			"ypos"			"0"
+			"wide"			"100"
+			"tall"			"31"
+			"visible"		"0"
+		
+			"UpgradeIcon"
+			{
+				"ControlName"	"CIconPanel"
+				"fieldName"		"UpgradeIcon"
+				"xpos"			"0"
+				"ypos"			"16"
+				"zpos"			"1"
+				"wide"			"10"
+				"tall"			"10"
+				"visible"		"1"
+				"enabled"		"1"
+				"scaleImage"	"1"	
+				"icon"			"ico_metal"
+				"iconColor"		"ProgressOffWhite"
+			}
+			
+			"Upgrade"
+			{	
+				"ControlName"	"ContinuousProgressBar"
+				"fieldName"		"Upgrade"
+				"font"			"Default"
+				"xpos"			"12"
+				"ypos"			"17"
+				"wide"			"38"
+				"tall"			"8"
+				"autoResize"	"0"
+				"pinCorner"		"0"
+				"visible"		"1"
+				"enabled"		"1"
+				"textAlignment"	"Left"
+				"dulltext"		"0"
+				"brighttext"	"0"
+			}
+		}
+	}
+}

--- a/resource/ui/hudammoweapons.res
+++ b/resource/ui/hudammoweapons.res
@@ -81,7 +81,7 @@
 		"ControlName"	"CExLabel"
 		"fieldName"		"AmmoInReserve"
 		"font"			"HudFontSmallBold"
-		"fgcolor"		"TanLight"
+		"fgcolor"		"White"
 		"xpos"			"67"
 		"ypos"			"8"
 		"zpos"			"7"

--- a/resource/ui/huditemeffectmeter.res
+++ b/resource/ui/huditemeffectmeter.res
@@ -6,9 +6,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"xpos"			"c160" //"r224"	[$WIN32]
-		"ypos"			"r52"	[$WIN32]
-		"xpos"			"r194"	[$X360]
-		"ypos"			"r74"	[$X360]
+		"ypos"			"r52"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"
@@ -22,7 +20,7 @@
 		"xpos"			"45"
 		"ypos"			"26"
 		"zpos"			"0"
-		"wide"			"34"
+		"wide"			"39"
 		"tall"			"16"
 		"visible"		"1"
 		"enabled"		"1"
@@ -43,7 +41,7 @@
 	{
 		"ControlName"			"CExLabel"
 		"fieldName"				"ItemEffectMeterLabel"
-		"xpos"					"42"
+		"xpos"					"44"
 		"ypos"					"30"
 		"zpos"					"2"
 		"wide"					"41"
@@ -68,7 +66,7 @@
 		"xpos"					"47"
 		"ypos"					"28"
 		"zpos"					"2"
-		"wide"					"30"
+		"wide"					"35"
 		"tall"					"5"				
 		"autoResize"			"0"
 		"pinCorner"				"0"

--- a/resource/ui/huditemeffectmeter_cleaver.res
+++ b/resource/ui/huditemeffectmeter_cleaver.res
@@ -6,9 +6,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"xpos"			"c160" //"r224"	[$WIN32]
-		"ypos"			"r70"	[$WIN32]
-		"xpos"			"r194"	[$X360]
-		"ypos"			"r74"	[$X360]
+		"ypos"			"r70"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"
@@ -22,7 +20,7 @@
 		"xpos"			"45"
 		"ypos"			"26"
 		"zpos"			"0"
-		"wide"			"34"
+		"wide"			"39"
 		"tall"			"16"
 		"visible"		"1"
 		"enabled"		"1"
@@ -43,7 +41,7 @@
 	{
 		"ControlName"			"CExLabel"
 		"fieldName"				"ItemEffectMeterLabel"
-		"xpos"					"41"
+		"xpos"					"44"
 		"ypos"					"30"
 		"zpos"					"2"
 		"wide"					"41"
@@ -68,7 +66,7 @@
 		"xpos"					"47"
 		"ypos"					"28"
 		"zpos"					"2"
-		"wide"					"30"
+		"wide"					"35"
 		"tall"					"5"				
 		"autoResize"			"0"
 		"pinCorner"				"0"

--- a/resource/ui/huditemeffectmeter_heavy.res
+++ b/resource/ui/huditemeffectmeter_heavy.res
@@ -6,9 +6,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"xpos"			"c160" //"r224"	[$WIN32]
-		"ypos"			"r70"	[$WIN32]
-		"xpos"			"r194"	[$X360]
-		"ypos"			"r74"	[$X360]
+		"ypos"			"r70"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"
@@ -22,7 +20,7 @@
 		"xpos"			"45"
 		"ypos"			"26"
 		"zpos"			"0"
-		"wide"			"34"
+		"wide"			"39"
 		"tall"			"16"
 		"visible"		"1"
 		"enabled"		"1"
@@ -43,7 +41,7 @@
 	{
 		"ControlName"			"CExLabel"
 		"fieldName"				"ItemEffectMeterLabel"
-		"xpos"					"41"
+		"xpos"					"44"
 		"ypos"					"30"
 		"zpos"					"2"
 		"wide"					"41"
@@ -68,7 +66,7 @@
 		"xpos"					"47"
 		"ypos"					"28"
 		"zpos"					"2"
-		"wide"					"30"
+		"wide"					"35"
 		"tall"					"5"				
 		"autoResize"			"0"
 		"pinCorner"				"0"

--- a/resource/ui/huditemeffectmeter_organs.res
+++ b/resource/ui/huditemeffectmeter_organs.res
@@ -5,8 +5,8 @@
 		"fieldName"		"HudItemEffectMeter"
 		"visible"		"1"
 		"enabled"		"1"
-		"xpos"			"c209" //"r208"	[$WIN32]
-		"ypos"			"r68"	[$WIN32]
+		"xpos"			"c220" //"r208"	[$WIN32]
+		"ypos"			"r68"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"
@@ -94,6 +94,7 @@
 		"textAlignment"			"north"
 		"dulltext"				"0"
 		"brighttext"			"0"
+		"fgcolor"				"White"
 		"font"					"HudFontMediumBold"
 	}
 

--- a/resource/ui/huditemeffectmeter_powerupbottle.res
+++ b/resource/ui/huditemeffectmeter_powerupbottle.res
@@ -110,6 +110,7 @@
 		"textAlignment"			"north"
 		"dulltext"				"0"
 		"brighttext"			"0"
+		"fgcolor"				"White"
 		"font"					"HudFontMediumBold"
 	}
 

--- a/resource/ui/huditemeffectmeter_scout.res
+++ b/resource/ui/huditemeffectmeter_scout.res
@@ -6,9 +6,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"xpos"			"c160" //"r224"	[$WIN32]
-		"ypos"			"r70"	[$WIN32]
-		"xpos"			"r194"	[$X360]
-		"ypos"			"r74"	[$X360]
+		"ypos"			"r70"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"
@@ -22,7 +20,7 @@
 		"xpos"			"45"
 		"ypos"			"26"
 		"zpos"			"0"
-		"wide"			"34"
+		"wide"			"39"
 		"tall"			"16"
 		"visible"		"1"
 		"enabled"		"1"
@@ -43,7 +41,7 @@
 	{
 		"ControlName"			"CExLabel"
 		"fieldName"				"ItemEffectMeterLabel"
-		"xpos"					"41"
+		"xpos"					"44"
 		"ypos"					"30"
 		"zpos"					"2"
 		"wide"					"41"
@@ -68,7 +66,7 @@
 		"xpos"					"47"
 		"ypos"					"28"
 		"zpos"					"2"
-		"wide"					"30"
+		"wide"					"35"
 		"tall"					"5"				
 		"autoResize"			"0"
 		"pinCorner"				"0"

--- a/resource/ui/huditemeffectmeter_sniper.res
+++ b/resource/ui/huditemeffectmeter_sniper.res
@@ -5,7 +5,7 @@
 		"fieldName"		"HudItemEffectMeter"
 		"visible"		"1"
 		"enabled"		"1"
-		"xpos"			"c210" //"r208"	[$WIN32]
+		"xpos"			"c215" //"r208"	[$WIN32]
 		"ypos"			"r50"	[$WIN32]
 		"wide"			"100"
 		"tall"			"50"
@@ -94,6 +94,7 @@
 		"textAlignment"			"north"
 		"dulltext"				"0"
 		"brighttext"			"0"
+		"fgcolor"				"White"
 		"font"					"HudFontMediumBold"
 	}
 

--- a/resource/ui/huditemeffectmeter_sniper.res
+++ b/resource/ui/huditemeffectmeter_sniper.res
@@ -5,8 +5,8 @@
 		"fieldName"		"HudItemEffectMeter"
 		"visible"		"1"
 		"enabled"		"1"
-		"xpos"			"c215" //"r208"	[$WIN32]
-		"ypos"			"r50"	[$WIN32]
+		"xpos"			"c216" //"r208"	[$WIN32]
+		"ypos"			"r50"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"

--- a/resource/ui/huditemeffectmeter_spy.res
+++ b/resource/ui/huditemeffectmeter_spy.res
@@ -5,8 +5,8 @@
 		"fieldName"		"HudItemEffectMeter"
 		"visible"		"1"
 		"enabled"		"1"
-		"xpos"			"c210" //"r208"	[$WIN32]
-		"ypos"			"r50"	[$WIN32]
+		"xpos"			"c216" //"r208"	[$WIN32]
+		"ypos"			"r50"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"
@@ -94,6 +94,7 @@
 		"textAlignment"			"north"
 		"dulltext"				"0"
 		"brighttext"			"0"
+		"fgcolor"				"White"
 		"font"					"HudFontMediumBold"
 	}
 

--- a/resource/ui/huditemeffectmeter_spyknife.res
+++ b/resource/ui/huditemeffectmeter_spyknife.res
@@ -6,9 +6,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"xpos"			"c160" //"r224"	[$WIN32]
-		"ypos"			"r70"	[$WIN32]
-		"xpos"			"r194"	[$X360]
-		"ypos"			"r74"	[$X360]
+		"ypos"			"r70"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"
@@ -22,7 +20,7 @@
 		"xpos"			"45"
 		"ypos"			"26"
 		"zpos"			"0"
-		"wide"			"34"
+		"wide"			"39"
 		"tall"			"16"
 		"visible"		"1"
 		"enabled"		"1"
@@ -43,7 +41,7 @@
 	{
 		"ControlName"			"CExLabel"
 		"fieldName"				"ItemEffectMeterLabel"
-		"xpos"					"41"
+		"xpos"					"44"
 		"ypos"					"30"
 		"zpos"					"2"
 		"wide"					"41"
@@ -68,7 +66,7 @@
 		"xpos"					"47"
 		"ypos"					"28"
 		"zpos"					"2"
-		"wide"					"30"
+		"wide"					"35"
 		"tall"					"5"				
 		"autoResize"			"0"
 		"pinCorner"				"0"

--- a/resource/ui/hudrocketpack.res
+++ b/resource/ui/hudrocketpack.res
@@ -1,4 +1,3 @@
-#base "HudItemEffectMeter.res"
 "Resource/UI/HudRocketPack.res"
 {
 	HudItemEffectMeter
@@ -6,8 +5,8 @@
 		"fieldName"		"HudItemEffectMeter"
 		"visible"		"1"
 		"enabled"		"1"
-		"xpos"			"c126"	[$WIN32]
-		"ypos"			"r65"	[$WIN32]
+		"xpos"			"c126"
+		"ypos"			"r65"
 		"wide"			"94"
 		"tall"			"45"
 	}
@@ -16,10 +15,10 @@
 	{
 		"ControlName"	"CTFImagePanel"
 		"fieldName"		"ItemEffectMeterBG"
-		"xpos"			"4"
+		"xpos"			"7"
 		"ypos"			"0"
 		"zpos"			"1"
-		"wide"			"75"
+		"wide"			"70"
 		"tall"			"25"
 		"visible"		"1"
 		"enabled"		"1"
@@ -27,7 +26,13 @@
 		"scaleImage"		"1"
 		"teambg_1"		"../hud/color_panel_brown"
 		"teambg_2"		"../hud/color_panel_red"
-		"teambg_3"		"../hud/color_panel_blu"				
+		"teambg_3"		"../hud/color_panel_blu"	
+
+		"src_corner_height"		"60"				// pixels inside the image
+		"src_corner_width"		"60"
+
+		"draw_corner_width"		"6"				// screen size of the corners ( and sides ), proportional
+		"draw_corner_height" 	"6"			
 	}
 
 	"ItemEffectIcon"
@@ -35,7 +40,7 @@
 		"ControlName"	"CTFImagePanel"
 		"fieldName"		"ItemEffectIcon"
 		"xpos"			"0"
-		"ypos"			"0"
+		"ypos"			"-1"
 		"zpos"			"2"
 		"wide"			"24"
 		"tall"			"24"
@@ -49,8 +54,8 @@
 	{
 		"ControlName"	"CExLabel"
 		"fieldName"		"ItemEffectMeterLabel"
-		"xpos"			"24"
-		"ypos"			"0"
+		"xpos"			"23"
+		"ypos"			"2"
 		"zpos"			"2"
 		"wide"			"90"
 		"tall"			"15"
@@ -63,7 +68,7 @@
 		"textAlignment"	"west"
 		"dulltext"		"0"
 		"brighttext"	"0"
-		"font"			"HudFontSmallestBold"
+		"font"			"HudFontSmallest"
 		"fgcolor"		"178 0 0 255"
 	}
 

--- a/resource/ui/spectator.res
+++ b/resource/ui/spectator.res
@@ -120,134 +120,45 @@
 
 	"ClassOrTeamLabel"
 	{
-		"ControlName"		"CExLabel"
+		"ControlName"	"CExLabel"
 		"fieldName"		"ClassOrTeamLabel"
-		"xpos"			"9999"// "c-85"
-		"ypos"			"68"
-		"ypos_hidef"	"90"
-		"ypos_lodef"	"30"
-		"wide"			"170"
-		"wide_hidef"	"130"
-		"wide_lodef"	"220"
-		"tall"			"15"
-		"tall_lodef"	"25"
-		"zpos"			"2"
-		"autoResize"		"0"
-		"pinCorner"		"0"
-		"visible"		"0"	[$WIN32]
-		"visible_minmode"		"0"
-		"visible"		"0"	[$X360]
-		"enabled"		"1"
-		"labelText"		"#TF_Spectator_ChangeTeam"
-		"textAlignment"		"center"
-		"textAlignment_lodef"		"north-west"
-		"font"			"SpectatorKeyHints"
-		"font_hidef"	"HudFontSmallest"
-		"font_lodef"	"HudFontSmall"
-		"wrap_lodef"			"1"
+		"xpos"			"9999"
 	}
 	"SwitchCamModeKeyLabel"
 	{
-		"ControlName"		"CExLabel"
+		"ControlName"	"CExLabel"
 		"fieldName"		"SwitchCamModeKeyLabel"
-		"xpos"			"5"
-		"ypos"			"10"
-		"wide"			"60"
-		"tall"			"20"
-		"autoResize"		"0"
-		"pinCorner"		"0"
-		"visible"		"0"
-		"visible_minmode"	"0"
-		"enabled"		"1"
-		"labelText"		"#TF_Spectator_ChangeTeam"
-		"textAlignment"		"east"
-		"font"			"SpectatorKeyHints"
-
+		"xpos"			"9999"
 	}
 	"SwitchCamModeLabel"
 	{
-		"ControlName"		"CExLabel"
+		"ControlName"	"CExLabel"
 		"fieldName"		"SwitchCamModeLabel"
-		"xpos"			"80"	[$WIN32]
-		"ypos"			"10"	[$WIN32]
-		"wide"			"125"	[$WIN32]
-		"tall"			"20"
-		"autoResize"		"0"
-		"pinCorner"		"0"
-		"visible"		"0"
-		"visible_minmode"	"0"
-		"enabled"		"1"
-		"labelText"		"#TF_Spectator_SwitchCamMode"
-		"textAlignment"		"west"
-		"font"			"SpectatorKeyHints"
+		"xpos"			"9999"
 	}
 	"CycleTargetFwdKeyLabel"
 	{
-		"ControlName"		"CExLabel"
+		"ControlName"	"CExLabel"
 		"fieldName"		"CycleTargetFwdKeyLabel"
-		"xpos"			"5"	[$WIN32]
-		"ypos"			"20"	[$WIN32]
-		"wide"			"60"	[$WIN32]
-		"tall"			"20"
-		"autoResize"		"0"
-		"pinCorner"		"0"
-		"visible"		"0"	[$WIN32]
-		"visible_minmode"	"0"
-		"enabled"		"1"
-		"labelText"		"#TF_Spectator_ClassOrTeamKey"
-		"textAlignment"		"east"
-		"font"			"SpectatorKeyHints"
+		"xpos"			"9999"
 	}
 	"CycleTargetFwdLabel"
 	{
-		"ControlName"		"CExLabel"
+		"ControlName"	"CExLabel"
 		"fieldName"		"CycleTargetFwdLabel"
-		"xpos"			"80"	[$WIN32]
-		"ypos"			"20"	[$WIN32]
-		"wide"			"125"	[$WIN32]
-		"tall"			"20"
-		"autoResize"		"0"
-		"pinCorner"		"0"
-		"visible"		"0"
-		"visible_minmode"	"0"
-		"enabled"		"1"
-		"labelText"		"#TF_Spectator_CycleTargetFwd"
-		"textAlignment"		"west"
-		"font"			"SpectatorKeyHints"
+		"xpos"			"9999"
 	}
 	"CycleTargetRevKeyLabel"
 	{
-		"ControlName"		"CExLabel"
+		"ControlName"	"CExLabel"
 		"fieldName"		"CycleTargetRevKeyLabel"
-		"xpos"			"5"	[$WIN32]
-		"ypos"			"30"	[$WIN32]
-		"wide"			"60"	[$WIN32]
-		"tall"			"20"
-		"autoResize"		"0"
-		"pinCorner"		"0"
-		"visible"		"0"
-		"visible_minmode"	"0"
-		"enabled"		"1"
-		"labelText"		"#TF_Spectator_ClassOrTeamKey"
-		"textAlignment"		"east"
-		"font"			"SpectatorKeyHints"
+		"xpos"			"9999"
 	}
 	"CycleTargetRevLabel"
 	{
-		"ControlName"		"CExLabel"
+		"ControlName"	"CExLabel"
 		"fieldName"		"CycleTargetRevLabel"
-		"xpos"			"80"	[$WIN32]
-		"ypos"			"30"	[$WIN32]
-		"wide"			"125"	[$WIN32]
-		"tall"			"20"
-		"autoResize"		"0"
-		"pinCorner"		"0"
-		"visible"		"0"
-		"visible_minmode"	"0"
-		"enabled"		"1"
-		"labelText"		"#TF_Spectator_CycleTargetRev"
-		"textAlignment"		"west"
-		"font"			"SpectatorKeyHints"
+		"xpos"			"9999"
 	}
 	"TipLabel"
 	{
@@ -261,10 +172,10 @@
 		"autoResize"		"0"
 		"pinCorner"		"0"
 		"visible"		"1"
+		"visible_minmode"	"0"
 		"enabled"		"1"
 		"labelText"		"%tip%"
 		"textAlignment"		"center"	[$WIN32]
-		"textAlignment"		"north-west"	[$X360]
 		"font"			"SpectatorKeyHints"
 		"font_hidef"	"HudFontSmall"
 		"font_lodef"	"DefaultVerySmall"


### PR DESCRIPTION
- Removed control labels from spectator HUD since I don't think they're really needed
- Updated "tip" label to hide it when minmode is enabled
- **Updated Engineer build status HUD to be more consistent with the rest of the in-game UI**
- Updated secondary ammo font color to match primary ammo (White)
- Updated Thermal Thruster HUD to be more consistent with rest of the in-game UI
- Updated some item meters to fix text going outside of them (e.g Razorback)
- Fixed "Organs" counter overlapping with the MVM Shield meter
- Fixed Diamondback "Crits" counter overlapping with spy item meters
- Fixed Bazaar Bargain "Heads" counter overlapping with sniper item meters
- Fixed some other small inconsistencies with the meters and counters

I looked through the issues page as well and it seems #26 is fixed already.

![20240122122026_1](https://github.com/TheKins/frankenhud/assets/50501742/f2162cb0-533b-4359-9d91-49081c266dbb)

![20240122122406_1](https://github.com/TheKins/frankenhud/assets/50501742/2a8894f9-5b4a-4ac4-a978-c6f47ac14172)

![20240122122415_1](https://github.com/TheKins/frankenhud/assets/50501742/2ab881a9-2963-4343-8ee8-81e1fccaa42b)

![20240122122055_1](https://github.com/TheKins/frankenhud/assets/50501742/469150ce-74b0-4880-8c1f-ecfa43be921b)

![pyro](https://github.com/TheKins/frankenhud/assets/50501742/ec24c733-c92d-4622-9942-d2523ecd8715)

![sniper](https://github.com/TheKins/frankenhud/assets/50501742/3a250d98-6904-4bbf-bba1-a200e0085eb5)

![diamondback](https://github.com/TheKins/frankenhud/assets/50501742/38c7437b-ab3e-4a6a-8ab9-3ff056b06215)

![Screenshot 2024-01-22 133924](https://github.com/TheKins/frankenhud/assets/50501742/a1a42b9f-fb50-4029-9ed1-2b0003f6bf1a)

